### PR TITLE
chore: run build-windows-x86 on windows-2022

### DIFF
--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -46,7 +46,7 @@ jobs:
           CI: true
 
   build-windows-x86:
-    runs-on: windows-2019
+    runs-on: windows-2022
     strategy:
       matrix:
         node_version: [18]


### PR DESCRIPTION
@achingbrain Can we run `build-windows-x86` on `windows-2022`? `windows-2019` are being deprecated this month (see https://github.com/actions/runner-images/issues/12045). The machines running `windows-2019` were `x64` machines so I don't think we were running that job on them for the matching architecture, but do you know if there's any other features from Windows Server 2019 that we need?